### PR TITLE
allow specified port to be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports.fixedName = function(test, tableName, tableDef) {
   return dynamo;
 };
 
-function ddbtest(test, projectName, tableDef, region) {
+function ddbtest(test, projectName, tableDef, region, port) {
   var live = !!region;
   tableDef = _(tableDef).clone();
 
@@ -34,6 +34,7 @@ function ddbtest(test, projectName, tableDef, region) {
   }
 
   var dynamodb = {};
+  port = port || '4567';
 
   dynamodb.tableName = tableDef.TableName = [
     'test',
@@ -47,7 +48,7 @@ function ddbtest(test, projectName, tableDef, region) {
     region: 'fake',
     accessKeyId: 'fake',
     secretAccessKey: 'fake',
-    endpoint: 'http://localhost:4567'
+    endpoint: 'http://localhost:' + port
   };
 
   dynamodb.dynamo = new AWS.DynamoDB(options);

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,9 @@ dynamodb.delete();
 
 Configure the `dynamodb` object by providing your own `tape` object, an arbitrary name for your project, and the JSON object that defines the table's schema. Optionally, you may specify a region. If you do, tests will be run against a live DynamoDB table in that region. If you don't, tests will be run against a local instance of [dynalite](https://github.com/mhart/dynalite). If you specify a port, dynalite will listen on it, otherwise it will use 4567.
 
-** var dynamodb = require('dynamodb-test').fixedName(tape, tableName, tableDef)**
+**var dynamodb = require('dynamodb-test').fixedName(tape, tableName, tableDef)**
 
-To configure a dynalite test runner with a fixed table name. 
+To configure a dynalite test runner with a fixed table name.
 
 **dynamodb.dynamo**
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,13 @@ test('provides sdks', function(assert) {
   assert.end();
 });
 
+test('respects port option', function(assert) {
+  assert.equal(mocked.config.endpoint, 'http://localhost:4567', 'uses default port');
+  var dbWithCustomPort = require('..')(test, project, tableDef, null, 1122);
+  assert.equal(dbWithCustomPort.config.endpoint, 'http://localhost:1122', 'uses specified port');
+  assert.end();
+});
+
 mocked.start();
 
 test('mocked start', function(assert) {


### PR DESCRIPTION
Closes #1

- Use optional `port` parameter + associated test
- Fix markdown error in readme
