### PR TITLE
Remove invalid params from CFN templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,11 @@ function ddbtest(test, projectName, tableDef, region, port) {
   var live = !!region;
   tableDef = _(tableDef).clone();
 
-  // DynamoDB's TimeToLiveSpecification is not valid for aws-sdk's createTable
-  // and is not supported in dynalite, so remove it.
+  // The following fields are not valid for aws-sdk's createTable and not
+  // supported in dynalite, so they are removed. They are commonly supplied
+  // from CFN templates.
   delete tableDef.TimeToLiveSpecification;
+  delete tableDef.PointInTimeRecoverySpecification;
 
   function getKeys(item) {
     var keyNames = tableDef.KeySchema.map(function(key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dynamodb-test",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dynamodb-test",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "ISC",
       "dependencies": {
         "@mapbox/dyno": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dynamodb-test",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Create and destroy DynamoDB and Dynalite tables for use in tape tests",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
CFN templates may supply a PITR configuration, which is not supported by the SDK table creation command or dynalite. Therefore, it will be removed from the parameters, if it's supplied.