### PR TITLE
use separate team names instead of parent team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mapbox/platform
+* @mapbox/cloud-platform @mapbox/data-platform


### PR DESCRIPTION
I don't think anyone monitors the @mapbox/platform team (and this is the only repo that is owned by it.) In general I think we use the pattern of assigning it to both teams.